### PR TITLE
Udpate WP version to 5.6

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.21] - 2021-01-19
+### Changed
+- Updated default WordPress image to `5.6-apache`.
+
 ## [0.5.20] - 2020-12-28
 ### Changed
 - Updated default repo org to `the-events-calendar`.

--- a/tric
+++ b/tric
@@ -27,7 +27,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.20';
+const CLI_VERSION = '0.5.21';
 
 $cli_header = implode( ' - ', [
 	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),

--- a/tric-stack.yml
+++ b/tric-stack.yml
@@ -30,7 +30,7 @@ services:
       dockerfile: ${TRIC_WORDPRESS_DOCKERFILE:-Dockerfile.debug}
       args:
         # Fix the version of the WordPress image to avoid issues w/ out-of-date database dumps.
-        WORDPRESS_IMAGE_VERSION: 5.5-apache
+        WORDPRESS_IMAGE_VERSION: 5.6-apache
         # Allow the image to be built creating the user and group ID for the host machine user.
         DOCKER_RUN_UID: ${DOCKER_RUN_UID:-0}
         DOCKER_RUN_GID: ${DOCKER_RUN_GID:-0}


### PR DESCRIPTION
This PR updates the WordPress image version used by the stack from `5.5` to `5.6`.

Users upgrading should:

1. Remove the `_wordpress` directory in `tric` root path; `rm -rf _wordpress`.
2. Run `tric update` to update and rebuild all images.
3. Run any command that will scaffold the `tric` WordPress installation anew; e.g. `tric up` or `tric serve`.

**Note**: the update to the newest version of WordPress will imply that the default theme will change from `twentytwenty` to `twentytwentyone`; snapshots tests will require update!