### PR TITLE
Add the composer-cache command

### DIFF
--- a/.env.tric
+++ b/.env.tric
@@ -67,3 +67,9 @@ MYSQL_ROOT_PASSWORD=password
 # =============================================
 # The localhost port the WordPress website will be served at.
 WORDPRESS_HTTP_PORT=8888
+
+# Cache directory on the host machine.
+COMPOSER_CACHE_HOST_DIR=/tmp
+
+# Directory the host machine's cache directory will be mapped to.
+COMPOSER_CACHE_DIR=

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The tric (Modern **Tri**be **C**ontainers) CLI command provides a containerized 
 
 1. Clone this repo
 2. Follow the [Setup Instructions](docs/setup.md)
+3. (Optional) Make [composer installs faster](docs/speedier-composer.md)
 
 ## Usage
 
@@ -128,6 +129,7 @@ Honestly, all of them are worth knowing. But here are a few important ones worth
 
 * `tric cli` – run WP CLI commands within the container stack.
 * `tric composer` – run composer commands against the current plugin target.
+* `tric composer-cache` – make composer faster by using your machine's compose cache directory.
 * `tric debug` – activates/deactivates debug output.
 * `tric info` – displays current `tric` environment settings.
 * `tric npm` – run npm commands against the current plugin target.

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.22] - 2021-01-20
+### Added
+- Added the `composer-cache` command so the host machine's composer cache can be leveraged within tric containers.
+
 ## [0.5.21] - 2021-01-19
 ### Changed
 - Updated default WordPress image to `5.6-apache`.

--- a/docs/speedier-composer.md
+++ b/docs/speedier-composer.md
@@ -1,0 +1,39 @@
+# Increasing the speed of composer
+
+By default, `tric` caches composer dependencies within the container
+and, when the containers are destroyed, so is the cache.
+
+## Do not despair!
+
+`tric` allows you to map your machine's composer cache directory into
+the `tric` containers so that repeated `tric composer` commands can benefit from
+composer cache as well! Simply:
+
+```bash
+tric composer-cache set /path/to/composer/cache
+
+# @borkweb's command that he uses:
+tric composer-cache set /home/matt/.cache/composer
+```
+
+## Removing the composer cache dir mapping
+
+You can disable the cache dir mapping via the following:
+
+```bash
+tric composer-cache unset
+```
+
+## Discovering what the mapping is set to
+
+You can see what the composer cache directory mapping is set to via:
+
+```bash
+tric composer-cache
+
+# OR via:
+
+tric info
+```
+
+*Note: When composer-cache is unset, it defaults to `/tmp`, though that mapped path is never used by composer.*

--- a/src/commands/composer-cache.php
+++ b/src/commands/composer-cache.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tribe\Test;
+
+if ( $is_help ) {
+	echo "Sets or displays the composer cache directory setting.\n";
+	echo PHP_EOL;
+	echo colorize( "signature: <light_cyan>{$cli_name} composer-cache [(set <dir>|unset)]</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>{$cli_name} composer-cache</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>{$cli_name} composer-cache /home/person/.cache/composer</light_cyan>\n" );
+	return;
+}
+
+$composer_cache_args = args( [ 'toggle', 'value' ], $args( '...' ), 0 );
+
+tric_handle_composer_cache( $composer_cache_args );

--- a/src/commands/composer-cache.php
+++ b/src/commands/composer-cache.php
@@ -7,7 +7,8 @@ if ( $is_help ) {
 	echo PHP_EOL;
 	echo colorize( "signature: <light_cyan>{$cli_name} composer-cache [(set <dir>|unset)]</light_cyan>\n" );
 	echo colorize( "example: <light_cyan>{$cli_name} composer-cache</light_cyan>\n" );
-	echo colorize( "example: <light_cyan>{$cli_name} composer-cache /home/person/.cache/composer</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>{$cli_name} composer-cache unset</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>{$cli_name} composer-cache set /home/person/.cache/composer</light_cyan>\n" );
 	return;
 }
 

--- a/src/utils.php
+++ b/src/utils.php
@@ -34,8 +34,8 @@ function args( array $map = [], array $source = null, $offset = 1 ) {
 		}
 
 		if ( '...' === $key ) {
-			$full_map [ $key ] = array_slice( $source, $position + $offset );
-			$parsed_variadic   = true;
+			$full_map[ $key ] = array_slice( $source, $position + $offset );
+			$parsed_variadic  = true;
 			continue;
 		}
 

--- a/tric
+++ b/tric
@@ -27,7 +27,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.21';
+const CLI_VERSION = '0.5.22';
 
 $cli_header = implode( ' - ', [
 	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),
@@ -54,6 +54,7 @@ Available commands:
 <light_cyan>here</light_cyan>           Sets the current plugins directory to be the one used by tric.
 <light_cyan>init</light_cyan>           Initializes a plugin for use in tric.
 <light_cyan>composer</light_cyan>       Runs a Composer command in the stack.
+<light_cyan>composer-cache</light_cyan> Sets or shows the composer cache directory.
 <light_cyan>npm</light_cyan>            Runs an npm command in the stack using the node 8.9 container.
 <light_cyan>npm_lts</light_cyan>        Runs an npm command in the stack using the node LTS container. 
 <light_cyan>target</light_cyan>         Runs a set of commands on a set of targets.
@@ -138,6 +139,7 @@ switch ( $subcommand ) {
 	case 'build-stack':
 	case 'build-subdir':
 	case 'composer':
+	case 'composer-cache':
 	case 'config':
 	case 'debug':
 	case 'down':

--- a/tric-stack.build.yml
+++ b/tric-stack.build.yml
@@ -56,6 +56,7 @@ services:
       # The port, in the container, is not the default `80` to allow non root users to bind (listen) to it.
       - "${WORDPRESS_HTTP_PORT:-8888}:80"
     environment:
+      COMPOSER_CACHE_DIR: ${COMPOSER_CACHE_DIR:-}
       WORDPRESS_DB_USER: root
       WORDPRESS_DB_PASSWORD: password
       # This db is created by the db container at startup, no need to create it.
@@ -86,3 +87,4 @@ services:
       # Paths are relative to the directory that contains this file, NOT the current working directory.
       # Share the WordPress core installation files in the `_wordpress` directory.
       - ${TRIC_WP_DIR}:/var/www/html:cached
+      - ${COMPOSER_CACHE_HOST_DIR}:/host-composer-cache:cached

--- a/tric-stack.site.yml
+++ b/tric-stack.site.yml
@@ -31,6 +31,7 @@ services:
     volumes:
       # Set the current target as project.
       - ${TRIC_HERE_DIR}/${TRIC_CURRENT_PROJECT_RELATIVE_PATH}:/project:cached
+      - ${COMPOSER_CACHE_HOST_DIR}:/host-composer-cache:cached
 
   npm:
     volumes:

--- a/tric-stack.yml
+++ b/tric-stack.yml
@@ -57,6 +57,7 @@ services:
       # The port, in the container, is not the default `80` to allow non root users to bind (listen) to it.
       - "${WORDPRESS_HTTP_PORT:-8888}:80"
     environment:
+      COMPOSER_CACHE_DIR: ${COMPOSER_CACHE_DIR:-}
       WORDPRESS_DB_USER: root
       WORDPRESS_DB_PASSWORD: password
       # This db is created by the db container at startup, no need to create it.
@@ -92,6 +93,7 @@ services:
       # Share the WordPress core installation files in the `_plugins` directory.
       - ${TRIC_PLUGINS_DIR}:/var/www/html/wp-content/plugins:cached
       - ${TRIC_THEMES_DIR}:/var/www/html/wp-content/themes:cached
+      - ${COMPOSER_CACHE_HOST_DIR}:/host-composer-cache:cached
 
   cli:
     image: wordpress:cli
@@ -184,6 +186,7 @@ services:
     user: "${DOCKER_RUN_UID:-}:${DOCKER_RUN_GID:-}"
     environment:
       FIXUID: "${FIXUID:-1}"
+      COMPOSER_CACHE_DIR: ${COMPOSER_CACHE_DIR:-}
       # Set these values to allow the container to look wordpress up.
       WORDPRESS_DB_USER: root
       WORDPRESS_DB_PASSWORD: password
@@ -229,17 +232,20 @@ services:
       # filesystem would be a worse cure than the disease.
       # The volume is bound to the `a+rwx` directory the `codeception` image provides to avoid file mode issues.
       - function-mocker-cache:/cache
+      - ${COMPOSER_CACHE_HOST_DIR}:/host-composer-cache:cached
 
   composer:
     image: lucatume/composer:php7.0
     user: "${DOCKER_RUN_UID:-}:${DOCKER_RUN_GID:-}"
     environment:
+      COMPOSER_CACHE_DIR: ${COMPOSER_CACHE_DIR:-}
       FIXUID: "${FIXUID:-1}"
     volumes:
       # Set the current plugin as project.
       - ${TRIC_PLUGINS_DIR}/${TRIC_CURRENT_PROJECT:-test}/${TRIC_CURRENT_PROJECT_SUBDIR:-}:/project:cached
       # Share SSH keys with the container to pull from private repositories.
       - ${DOCKER_RUN_SSH_AUTH_SOCK}:/ssh-agent:ro
+      - ${COMPOSER_CACHE_HOST_DIR}:/host-composer-cache:cached
 
   npm:
     build:


### PR DESCRIPTION
This command allows you to map a composer cache directory into the tric containers so that `tric composer` commands can benefit from cached dependencies.

This should help us speed up our GitHub Actions when we leverage `action/cache@v2`!

New command is: `tric composer-cache [(set <dir>|unset)]`

:movie_camera: https://d.pr/v/mqG0Tk

**Note:** I apologize in advance, my mind went blank partway through the video and I stuttered and stammered a bit while waiting for composer to fetch dependencies. Ultimately I don't care enough to re-record as it doesn't waste any time :D