### PR TITLE
Support wp argument in reste command to rm WP default dir

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.22] - 2021-01-20
+### Changed
+- Add an argument, to the `reset` command, to remove the default WordPress (`/_wordpress`) installation directory 
+  using `tric reset wp`.
+
 ## [0.5.21] - 2021-01-19
 ### Changed
 - Updated default WordPress image to `5.6-apache`.

--- a/src/commands/composer-cache.php
+++ b/src/commands/composer-cache.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Handles the `reset` command to reset tric to its initial state.
+ * Handles the `composer-cache` command.
  *
  * @var bool     $is_help  Whether we're handling an `help` request on this command or not.
  * @var string   $cli_name The current name of tric CLI binary.

--- a/src/commands/reset.php
+++ b/src/commands/reset.php
@@ -1,16 +1,50 @@
 <?php
+/**
+ * Handles the `reset` command to reset tric to its initial state.
+ *
+ * @var bool     $is_help Whether we're handling an `help` request on this command or not.
+ * @var \Closure $args    The argument map closure, as produced by the `args` function.
+ */
 
 namespace Tribe\Test;
 
 if ( $is_help ) {
-	echo "Resets the tool to its initial state configured by the env files.\n";
+	echo "Resets the tool to its initial state configured by the env files.\n" .
+	     "Additionally remove the default WP directory.\n";
 	echo PHP_EOL;
-	echo colorize( "usage: <light_cyan>{$cli_name} reset</light_cyan>" );
+	echo colorize( "usage: <light_cyan>{$cli_name} reset [wp]</light_cyan>\n" );
+	echo colorize( "example: <light_cyan>{$cli_name} reset </light_cyan>\n" );
+	echo colorize( "example: <light_cyan>{$cli_name} reset wp</light_cyan>\n" );
+
 	return;
 }
 
+$targets = $args( '...' );
+
+if ( in_array( 'wp', $targets, true ) && is_dir( root( '_wordpress' ) ) ) {
+	echo "Removing the _wordpress directory ...";
+
+	if ( false === rrmdir( root( '_wordpress' ) ) ) {
+		echo magenta( "\nCould not remove the _wordpress directory; remove it manually.\n" );
+		exit( 1 );
+	}
+
+	if ( ! mkdir( $wp_dir = root( '_wordpress' ) ) && ! is_dir( $wp_dir ) ) {
+		echo magenta( "\nCould not create the _wordpress directory; create it manually.\n" );
+		exit( 1 );
+	}
+
+	echo light_cyan( " done\n" );
+
+	return;
+}
+
+$run_settings_file = root( '/.env.tric.run' );
+echo "Removing {$run_settings_file} ...";
+
 if ( ! file_exists( $run_settings_file ) ) {
 	echo light_cyan( 'Done' );
+
 	return;
 }
 
@@ -21,4 +55,4 @@ if ( false === $removed ) {
 	exit( 1 );
 }
 
-echo light_cyan( 'Done' );
+echo light_cyan( ' done' );

--- a/src/commands/xdebug.php
+++ b/src/commands/xdebug.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * Handles the `xdebug` command.
+ *
+ * @var bool     $is_help  Whether we're handling an `help` request on this command or not.
+ * @var string   $cli_name The current name of tric CLI binary.
+ * @var \Closure $args     The argument map closure, as produced by the `args` function.
+ */
 
 namespace Tribe\Test;
 

--- a/src/utils.php
+++ b/src/utils.php
@@ -578,7 +578,8 @@ function rrmdir( $dir ) {
 	$files = new \RecursiveIteratorIterator (
 		new \RecursiveDirectoryIterator(
 			$dir,
-			\RecursiveDirectoryIterator::SKIP_DOTS ),
+			\RecursiveDirectoryIterator::SKIP_DOTS
+		),
 		\RecursiveIteratorIterator::CHILD_FIRST
 	);
 

--- a/src/utils.php
+++ b/src/utils.php
@@ -558,3 +558,43 @@ function upper_snake_case( $string ) {
 function snake_case( $string ) {
 	return preg_replace( '/[^\\w_]/', '_', $string ) ?: $string;
 }
+
+/**
+ * Removes a directory and all its contents recursively.
+ *
+ * @param string $dir The path to the directory to remove.
+ *
+ * @return bool Whether the removal was correctly completed or not.
+ */
+function rrmdir( $dir ) {
+	if ( empty( $dir ) || ! file_exists( $dir ) ) {
+		return true;
+	}
+
+	if ( is_file( $dir ) || is_link( $dir ) ) {
+		return unlink( $dir );
+	}
+
+	$files = new \RecursiveIteratorIterator (
+		new \RecursiveDirectoryIterator(
+			$dir,
+			\RecursiveDirectoryIterator::SKIP_DOTS ),
+		\RecursiveIteratorIterator::CHILD_FIRST
+	);
+
+	/** @var \SplFileInfo $fileinfo
+	 */
+	foreach ( $files as $fileinfo ) {
+		if ( $fileinfo->isDir() ) {
+			if ( rrmdir( $fileinfo->getRealPath() ) === false ) {
+				return false;
+			}
+		} else {
+			if ( unlink( $fileinfo->getRealPath() ) === false ) {
+				return false;
+			}
+		}
+	}
+
+	return rmdir( $dir );
+}

--- a/tric
+++ b/tric
@@ -27,7 +27,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.21';
+const CLI_VERSION = '0.5.22';
 
 $cli_header = implode( ' - ', [
 	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),


### PR DESCRIPTION
[Screencast](https://drive.google.com/open?id=1KYXB7VN4Na6JlNczAdnIzlBHKil5eqA1&authuser=luca%40tri.be&usp=drive_fs) 

This PR extends the `tric reset` command to support the `wp` argument.

The command `tric reset` would remove `tric` run configuration, the `.env.tric.run` file; the `tric reset wp` command will, instead, remove (recursively) the default WordPress directory used by `tric` in `/_wordpress`.

The command will not do the same for a custom set wp directory.

Changelog and version follow #71
