### PR TITLE
Update WP version in build file to 5.6

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.24] - 2021-02-18
+### Changed
+- Update the WordPress image version, in the `tric-stack.build.yml` file, from `5.5` to `5.6` to fix CI build issues.
+
 ## [0.5.23] - 2021-01-20
 ### Changed
 - Add an argument, to the `reset` command, to remove the default WordPress (`/_wordpress`) installation directory 

--- a/tric
+++ b/tric
@@ -27,7 +27,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.23';
+const CLI_VERSION = '0.5.24';
 
 $cli_header = implode( ' - ', [
 	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),

--- a/tric-stack.build.yml
+++ b/tric-stack.build.yml
@@ -30,7 +30,7 @@ services:
       dockerfile: ${TRIC_WORDPRESS_DOCKERFILE:-Dockerfile.debug}
       args:
         # Fix the version of the WordPress image to avoid issues w/ out-of-date database dumps.
-        WORDPRESS_IMAGE_VERSION: 5.5-apache
+        WORDPRESS_IMAGE_VERSION: 5.6-apache
         # Allow the image to be built creating the user and group ID for the host machine user.
         DOCKER_RUN_UID: ${DOCKER_RUN_UID:-0}
         DOCKER_RUN_GID: ${DOCKER_RUN_GID:-0}


### PR DESCRIPTION
Due to a mis-alignment between the main `tric-stack.yml` file and the `tric-stack.build.yaml` one, `tric` would set up WP 5.5 in CI, not 5.6 as expected, this PR fixes it.