### PR TITLE
Avoid .htaccess file being created by Composer

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.25] - 2021-03-02
+### Changed
+- Set `COMPOSER_HTACCESS_PROTECT=0` explicitly in the `docker-compose` configuration file to avoid an `.htaccess` 
+  file being created in the root directory of the current target.
+
 ## [0.5.24] - 2021-02-18
 ### Changed
 - Update the WordPress image version, in the `tric-stack.build.yml` file, from `5.5` to `5.6` to fix CI build issues.

--- a/tric
+++ b/tric
@@ -27,7 +27,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.24';
+const CLI_VERSION = '0.5.25';
 
 $cli_header = implode( ' - ', [
 	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),

--- a/tric-stack.yml
+++ b/tric-stack.yml
@@ -238,6 +238,7 @@ services:
     image: lucatume/composer:php7.0
     user: "${DOCKER_RUN_UID:-}:${DOCKER_RUN_GID:-}"
     environment:
+      COMPOSER_HTACCESS_PROTECT: 0
       COMPOSER_CACHE_DIR: ${COMPOSER_CACHE_DIR:-}
       FIXUID: "${FIXUID:-1}"
     volumes:


### PR DESCRIPTION
This PR modifies the `composer` service configuration in the `tric-stack.yml` file, the base `docker-compose` configuration file, to avoid Composer creating an `.htaccess` file in the root directory of the current target.

This would cause, in our CI and local systems using Apache as web-server, to have the project root directory denied all access with varying degrees of drama.  
