### PR TITLE
Open a shell in the wp-cli container on tric cli

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.26] - 2021-03-05
+### Changed
+- Allow opening a shell in the `cli` service to run wp-cli commands just using `tric cli`.
+
 ## [0.5.25] - 2021-03-02
 ### Changed
 - Set `COMPOSER_HTACCESS_PROTECT=0` explicitly in the `docker-compose` configuration file to avoid an `.htaccess` 

--- a/src/commands/cli.php
+++ b/src/commands/cli.php
@@ -28,7 +28,8 @@ if ( ! $open_bash_shell ) {
 	$user = getenv( 'DOCKER_RUN_UID' );
 	// Do not run the wp-cli container as `root` to avoid a number of file mode issues, run as `www-data` instead.
 	$user   = empty( $user ) ? 'www-data' : $user;
-	$status = tric_realtime()( [ 'run', '--rm', "--user={$user}", '--entrypoint', 'bash', 'cli' ] );
-}
 
+	$status = tric_realtime()( [ 'run', '-e PS1="wp-cli » "', '--rm', "--user={$user}", '--entrypoint', 'bash', 'cli' ] );
+
+}
 exit( $status );

--- a/src/commands/cli.php
+++ b/src/commands/cli.php
@@ -18,7 +18,9 @@ $command = $args( '...' );
  * wp-cli already comes with a `shell` command that will open a PHP shell, same as `php -a`, in it.
  * As much as it would be ideal to use the `shell` sub-command to open a shell... we cannot use the `shell` word.
  */
-$open_bash_shell = reset( $command ) === 'bash';
+$cli_command = reset( $command );
+// If the command is `bash` or is empty, then open a shell in the `cli` service.
+$open_bash_shell = empty( $cli_command ) || $cli_command === 'bash';
 if ( ! $open_bash_shell ) {
 	$status = tric_realtime()( cli_command( $command ) );
 } else {

--- a/tric
+++ b/tric
@@ -27,7 +27,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.25';
+const CLI_VERSION = '0.5.26';
 
 $cli_header = implode( ' - ', [
 	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),


### PR DESCRIPTION
I cannot post a video due to bad connection.

What the PR does is making it so that runnign `tric cli` will open a shell in the `cli` container that will operate on the current stack.
This would allow controlling the served site (`tric serve`) using wp-cli.

The PR does keep the same functionality bound to the `tric cli bash` command and does allow to keep runnign one-off commands like `tric cli site empty --yes --uploads`.
