### PR TITLE
Update tric.php

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.27] - 2021-06-03
+### Changed
+- Fixed an issue where the path to the WP directory would not build correctly on Windows systems.
+
 ## [0.5.26] - 2021-03-05
 ### Changed
 - Allow opening a shell in the `cli` service to run wp-cli commands just using `tric cli`.

--- a/src/tric.php
+++ b/src/tric.php
@@ -193,7 +193,7 @@ function setup_tric_env( $root_dir ) {
 	if ( empty( $wp_dir ) ) {
 		$wp_dir = root( '_wordpress' );
 	} elseif ( ! is_dir( $wp_dir ) ) {
-		$wp_dir_path = root( ltrim( $wp_dir, './' ) );
+		$wp_dir_path = trim(root( ltrim( $wp_dir, './' ) ));
 
 		if (
 			is_dir( dirname( $wp_dir_path ) )

--- a/tric
+++ b/tric
@@ -27,7 +27,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.26';
+const CLI_VERSION = '0.5.27';
 
 $cli_header = implode( ' - ', [
 	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),


### PR DESCRIPTION
Eugene and i had an issue on Windows machines where tric would error out when you tried to run locally.  You would receive the error "directoryate the {path for _wordpress}". 

Screenshots: 
https://prnt.sc/13o74p8
https://prnt.sc/13o78ze

Added a trim to the $wp_dir_path variable

Eugene and myself tested and the change worked.