### PR TITLE
Add host-ip command

### DIFF
--- a/src/commands/host-ip.php
+++ b/src/commands/host-ip.php
@@ -1,0 +1,14 @@
+<?php
+namespace Tribe\Test;
+
+if ( $is_help ) {
+    echo "Returns the IP Address of the host machine from the container perspective.\n";
+    echo PHP_EOL;
+    echo colorize( "example: <light_cyan>{$cli_name} host-ip</light_cyan>\n" );
+    return;
+}
+
+// Buffer the output to avoid printing empty blank lines that might mangle the output in quite mode.
+ob_start();
+tric_passive()( [ 'run', '--rm', 'host-ip' ] );
+echo trim( ob_get_clean() );

--- a/tric
+++ b/tric
@@ -27,14 +27,23 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.27';
+const CLI_VERSION = '0.5.28';
 
-$cli_header = implode( ' - ', [
-	light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),
-	light_cyan( 'TEC local testing and development tool' )
-] );
-
-echo $cli_header . PHP_EOL . PHP_EOL;
+// If the run-time option `-q`, for "quiet", is specified, then do not print the header.
+if ( in_array( '-q', $argv, true ) ) {
+    // Remove the `-q` flag from the global array of arguments to leave the rest of the commands unchanged.
+	unset( $argv[ array_search( '-q', $argv ) ] );
+	$argv = array_values( $argv );
+	$argc = count( $argv );
+	// Define a const commands will be able to check for quietness.
+	define( 'TRIC_QUIET', true );
+} else {
+	$cli_header = implode( ' - ', [
+		light_cyan( $cli_name ) . ' version ' . light_cyan( CLI_VERSION ),
+		light_cyan( 'TEC local testing and development tool' )
+	] );
+	echo $cli_header . PHP_EOL . PHP_EOL;
+}
 
 define( 'TRIC_ROOT_DIR', __DIR__ );
 
@@ -85,6 +94,7 @@ Available commands:
 
 <yellow>Containers:</yellow>
 <light_cyan>build-stack</light_cyan>    Builds the stack containers that require it, or builds a specific service image.
+<light_cyan>host-ip</light_cyan>        Returns the IP Address of the host machine from the container perspective.
 <light_cyan>down</light_cyan>           Tears down the stack, stopping containers and removing volumes.
 <light_cyan>up</light_cyan>             Starts a container part of the stack.
 <light_cyan>restart</light_cyan>        Restarts a container part of the stack.
@@ -144,6 +154,7 @@ switch ( $subcommand ) {
 	case 'debug':
 	case 'down':
 	case 'here':
+    case 'host-ip':
 	case 'info':
 	case 'init':
 	case 'interactive':

--- a/tric-stack.yml
+++ b/tric-stack.yml
@@ -317,3 +317,10 @@ services:
       - redis
     entrypoint: ["redis-cli","-h redis","-p 6379"]
     command: ["--version"]
+
+  host-ip:
+    image: busybox
+    networks:
+      tric:
+    entrypoint: sh
+    command: -c '/bin/ip route | awk "/default/ { print $$3 }" | cut -d" " -f3'


### PR DESCRIPTION
When configuring `tric` on systems that do not support the
out-of-the-box `host.internal.docker` redirection, i.e. any Linux
system, then finding out the IP Address of the Docker host machine from
the perspective of the the containers can be a bit tricky and
unreliable.

The purpose of this command is to make it easy to find that IP Address
and script its usage by means of the `-q` (for "quiet") option.

Example usage would be the one to configure XDebug in one-liner:
`tric xdebug host $(tric host-ip -q)`
