### PR TITLE
Support MailCatcher container

### DIFF
--- a/tric-stack.yml
+++ b/tric-stack.yml
@@ -318,6 +318,15 @@ services:
     entrypoint: ["redis-cli","-h redis","-p 6379"]
     command: ["--version"]
 
+  mailcatcher:
+    image: dockage/mailcatcher
+    networks:
+      tric:
+    ports:
+      # Expose MailCatcher ports on localhost.
+      - "1025:1025"
+      - "1080:1080"
+
   host-ip:
     image: busybox
     networks:


### PR DESCRIPTION
When doing an Acceptance test, it can be difficult to know whether an email was sent or not. MailCatcher helps with this and I believe after testing that it is the idea candidate to be included within Tric to test whether emails were correctly sent, get information about those emails, and create assertions about those emails.

This PR adds a new [MailCatcher container](https://github.com/dockage/mailcatcher) that lets you talk to the [MailCatcher service](https://mailcatcher.me/) through the very handy [MailCatcher Codeception Module](https://github.com/captbaritone/codeception-mailcatcher-module) when using Acceptance tests.

## Example config for `acceptance.suite.yml`

```yml
modules:
    enabled:
        - MailCatcher
    config:
        MailCatcher:
            url: 'http://127.0.0.1'
            port: '1080'

```

## Example usage in acceptance test

```php
<?php

$I->wantTo('Get a password reset email');

// Clear old emails from MailCatcher
$I->resetEmails();

// Reset password
$I->amOnPage('forgotPassword.php');
$I->fillField("input[name='email']", 'user@example.com');
$I->click('Submit');
$I->see('Please check your inbox');

$I->seeInLastEmail('Please click this link to reset your password');
```