### PR TITLE
ARM support and Xdebug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ _plugins
 .build-version
 # Any .remote-version file created by the tric cli tool.
 .remote-version
+# Any architecture detection flag file.
+.architecture_arm64
+.architecture_x86

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.30] - 2022-03-10
+#### Changed
+- Use the `seleniarm/standalone-chromium` container for the `chrome` service on ARM architecture machines.
+- Add the `pcntl` extension to the `codeception` container.
+
 ## [0.5.29] - 2021-11-29
 #### Changed
 - Add support for a Mailcatcher container (thanks @sc0ttkclark).

--- a/containers/wordpress/Dockerfile.debug
+++ b/containers/wordpress/Dockerfile.debug
@@ -15,8 +15,9 @@ COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr
 # Install the XDebug extension, drama might ensue due to the version constraint, handle it.
 # Install version 2 to keep the same config most people have.
 RUN install-php-extensions xdebug-2.9.8 || docker-php-ext-enable xdebug.so
-# Configure XDebug to autostart on all requests, use the version 2 configuration format.
+# Configure XDebug to autostart on all requests, use the version 2 and 3 configuration format.
 RUN echo 'xdebug.remote_enable=1\n\
+xdebug.mode=develop,debug\n\
 xdebug.remote_autostart=1\n' \
  >> /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 # Make the XDebug configuration file world-read/writeable as the user updating it might not be a sudo-er.

--- a/tric
+++ b/tric
@@ -27,7 +27,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.29';
+const CLI_VERSION = '0.5.30';
 
 // If the run-time option `-q`, for "quiet", is specified, then do not print the header.
 if ( in_array( '-q', $argv, true ) ) {

--- a/tric-stack.yml
+++ b/tric-stack.yml
@@ -83,7 +83,7 @@ services:
       # within the container, on macOS and Windows.
       # On Linux set the host machine IP address before calling the stack:
       # XDH=$(ip route | grep docker0 | awk '{print $9}') docker-compose ...
-      XDEBUG_CONFIG: "idekey=${XDK:-tric} remote_enable=${XDE:-1} remote_host=${XDH:-host.docker.internal} remote_port=${XDP:-9001}"
+      XDEBUG_CONFIG: "idekey=${XDK:-tric} remote_enable=${XDE:-1} remote_host=${XDH:-host.docker.internal} remote_port=${XDP:-9001} client_host=${XDH:-host.docker.internal} client_port=${XDP:-9001}"
       # Whether to disable the XDebug extension in the Codeception container completely or not.
       XDEBUG_DISABLE: "${XDEBUG_DISABLE:-0}"
     volumes:
@@ -110,7 +110,7 @@ services:
       # within the container, on macOS and Windows.
       # On Linux set the host machine IP address before calling the stack:
       # XDH=$(ip route | grep docker0 | awk '{print $9}') docker-compose ...
-      XDEBUG_CONFIG: "idekey=${XDK:-tric} remote_enable=${XDE:-1} remote_host=${XDH:-host.docker.internal} remote_port=${XDP:-9001}"
+      XDEBUG_CONFIG: "idekey=${XDK:-tric} remote_enable=${XDE:-1} remote_host=${XDH:-host.docker.internal} remote_port=${XDP:-9001} client_host=${XDH:-host.docker.internal} client_port=${XDP:-9001}"
     volumes:
       # Paths are relative to the directory that contains this file, NOT the current working directory.
       # Share the WordPress core installation files in the `_wordpress` directory.
@@ -136,7 +136,7 @@ services:
       # within the container, on macOS and Windows.
       # On Linux set the host machine IP address before calling the stack:
       # XDH=$(ip route | grep docker0 | awk '{print $9}') docker-compose ...
-      XDEBUG_CONFIG: "idekey=${XDK:-tric} remote_enable=${XDE:-1} remote_host=${XDH:-host.docker.internal} remote_port=${XDP:-9001}"
+      XDEBUG_CONFIG: "idekey=${XDK:-tric} remote_enable=${XDE:-1} remote_host=${XDH:-host.docker.internal} remote_port=${XDP:-9001} client_host=${XDH:-host.docker.internal} client_port=${XDP:-9001}"
     depends_on:
       - wordpress
     # Override the default entrypoint to wait for the WordPress container, and required services to be up and running.
@@ -171,7 +171,7 @@ services:
     command: -Lkfv --retry-connrefused --retry 30 --retry-delay 1 -o /dev/null --stderr /dev/null wordpress.test:80
 
   chrome:
-    image: selenium/standalone-chrome:3.141.59-oxygen
+    image: ${TRIC_CHROME_CONTAINER:-selenium/standalone-chrome:3.141.59-oxygen}
     networks:
       - tric
     extra_hosts:
@@ -201,7 +201,7 @@ services:
       # within the container, on macOS and Windows.
       # On Linux set the host machine IP address before calling the stack:
       # XDH=$(ip route | grep docker0 | awk '{print $9}') docker-compose ...
-      XDEBUG_CONFIG: "idekey=${XDK:-tric} remote_enable=${XDE:-1} remote_host=${XDH:-host.docker.internal} remote_port=${XDP:-9001}"
+      XDEBUG_CONFIG: "idekey=${XDK:-tric} remote_enable=${XDE:-1} remote_host=${XDH:-host.docker.internal} remote_port=${XDP:-9001} client_host=${XDH:-host.docker.internal} client_port=${XDP:-9001}"
       # Move to the target directory before running the command from the plugins directory.
       CODECEPTION_PROJECT_DIR: /var/www/html/wp-content/plugins/${TRIC_CURRENT_PROJECT:-test}/${TRIC_CURRENT_PROJECT_SUBDIR:-}
       # When running the container in shell mode (using the tric `shell` command), then use this CC configuration.

--- a/tric-stack.yml
+++ b/tric-stack.yml
@@ -178,7 +178,7 @@ services:
       - "wordpress.test:172.${TRIC_TEST_SUBNET:-28}.1.1"
 
   codeception:
-    image: lucatume/codeception:cc3.1.0
+    image: lucatume/codeception:latest
     networks:
       - tric
     extra_hosts:


### PR DESCRIPTION
This PR handles two issues I ran into:

1. Add support for ARM architecture by using a different container for the `chrome` service when using `arm64` architecture.
2. Update the XDebug settings to make sure they would work the same on v2 (now deprecated) and v3.

- feat(src) detect arm64 architecture
- refactor(trick-stack.yml) diff. Chrome dep. on arch.
