### PR TITLE
Bump version to pull fixed container

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.31] - 2022-03-14
+#### Changed
+- Version bump to pull the latest version of the fixed `codeception` container.
+
 ## [0.5.30] - 2022-03-10
 #### Changed
 - Use the `seleniarm/standalone-chromium` container for the `chrome` service on ARM architecture machines.

--- a/tric
+++ b/tric
@@ -27,7 +27,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.30';
+const CLI_VERSION = '0.5.31';
 
 // If the run-time option `-q`, for "quiet", is specified, then do not print the header.
 if ( in_array( '-q', $argv, true ) ) {


### PR DESCRIPTION
This PR just bumps the version to trigger an update message on `tric` main screen and a user update to pull the fixed version of the Codeception container.
