### PR TITLE
Fix the version of the CC container

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.32] - 2022-03-18
+#### Changed
+- Set the version of the `lucatume/codeception` container to `cc3.1.0-v1.1.1`.
+
 ## [0.5.31] - 2022-03-14
 #### Changed
 - Version bump to pull the latest version of the fixed `codeception` container.

--- a/tric
+++ b/tric
@@ -27,7 +27,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.31';
+const CLI_VERSION = '0.5.32';
 
 // If the run-time option `-q`, for "quiet", is specified, then do not print the header.
 if ( in_array( '-q', $argv, true ) ) {

--- a/tric-stack.yml
+++ b/tric-stack.yml
@@ -178,7 +178,7 @@ services:
       - "wordpress.test:172.${TRIC_TEST_SUBNET:-28}.1.1"
 
   codeception:
-    image: lucatume/codeception:latest
+    image: lucatume/codeception:cc3.1.0-v1.1.1
     networks:
       - tric
     extra_hosts:


### PR DESCRIPTION
In the previous version, `0.5.31`, I had set the version of the `lucatume/codeception` container to `latest`.
That would pull the new version of the container, based on PHP 7.4, not PHP 7.3.  The PHP version upgrade would break some vendor libraries not compatible with PHP 7.4.
This commit fixes the version of the container to `cc3.1.0-v1.1.1`, the `cc3.1.0` part will make it so the base container is based on PHP version 7.4, and the fixed version makes sure `tric` will not depend on the latest version, but on a very specific one.
