### PR TITLE
Add mysql command

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.33] - 2022-03-18
+#### Changed
+- Add the `mysql` command to quickly open a `mysql` shell in the running database container of the `tric` stack.
+- Add the `wp` command as alias of the `cli` command. 
+
 ## [0.5.32] - 2022-03-18
 #### Changed
 - Set the version of the `lucatume/codeception` container to `cc3.1.0-v1.1.1`.

--- a/src/commands/mysql.php
+++ b/src/commands/mysql.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Opens a mysql shell in the database service.
+ *
+ * If the database is not currently up, then the command will exit with a failure status.
+ *
+ * @var bool   $is_help  Whether the current user request is to get help about the command or not.
+ * @var string $cli_name The current name of the ClI application, usually `tric`.
+ */
+
+namespace Tribe\Test;
+
+if ( $is_help ) {
+	echo "Opens a mysql shell in the database service.\n";
+	echo PHP_EOL;
+	echo colorize( "usage: <light_cyan>{$cli_name} mysql\n" );
+
+	return;
+}
+
+setup_id();
+
+// Run the command in the container, exit the same status as the process.
+$db_root_password = 'password'; // @todo get it from the env
+$status           = tric_realtime()( [ 'exec', 'db', 'mysql', "-uroot", "-p{$db_root_password}" ] );
+
+exit( $status );

--- a/tric
+++ b/tric
@@ -27,7 +27,7 @@ $args = args( [
 ] );
 
 $cli_name = basename( $argv[0] );
-const CLI_VERSION = '0.5.32';
+const CLI_VERSION = '0.5.33';
 
 // If the run-time option `-q`, for "quiet", is specified, then do not print the header.
 if ( in_array( '-q', $argv, true ) ) {
@@ -77,10 +77,12 @@ Available commands:
 <light_cyan>shell</light_cyan>          Opens a shell in a new stack service, defaults to the 'codeception' one.
 <light_cyan>ssh</light_cyan>            Opens a shell in a running stack service, defaults to the 'wordpress' one.
 <light_cyan>cli</light_cyan>            Runs a wp-cli command in the stack or opens a session into the wp-cli container.
+<light_cyan>wp</light_cyan>             Runs a wp-cli command in the stack or opens a session into the wp-cli container; alias of 'cli'.
 <light_cyan>site-cli</light_cyan>       Waits for WordPress to be correctly set up to run a wp-cli command in the stack.
 <light_cyan>reset</light_cyan>          Resets {$cli_name} to the initial state as configured by the env files.
 <light_cyan>update</light_cyan>         Updates the tool and the images used in its services.
 <light_cyan>upgrade</light_cyan>        Upgrades the {$cli_name} repo.
+<light_cyan>mysql</light_cyan>          Opens a mysql shell in the database service.
 
 <yellow>Info:</yellow>
 <light_cyan>build-prompt</light_cyan>   Activates or deactivates whether or not composer/npm build prompts should be provided.
@@ -120,6 +122,11 @@ if ( ! in_array( $subcommand, [ 'help', 'update'] ) ) {
 	maybe_prompt_for_stack_update();
 }
 
+// A map from the user-facing alias to the command that will be actually called.
+$aliases = [
+	'wp' => 'cli',
+];
+
 switch ( $subcommand ) {
 	default:
 	case 'help':
@@ -140,6 +147,7 @@ switch ( $subcommand ) {
 	case 'airplane-mode':
 	case 'cache':
 	case 'cli':
+	case 'wp': // Alias of the `cli` command.
 		scaffold_installation();
 		install_wordpress();
 		// Do not break, let the command be loaded then.
@@ -157,6 +165,7 @@ switch ( $subcommand ) {
 	case 'init':
 	case 'interactive':
 	case 'logs':
+	case 'mysql':
 	case 'npm':
 	case 'npm_lts':
 	case 'phpcbf':
@@ -168,6 +177,9 @@ switch ( $subcommand ) {
 	case 'use':
 	case 'using':
 	case 'xdebug':
+        if ( isset( $aliases[ $subcommand ] ) ) {
+            $subcommand = $aliases[ $subcommand ];
+        }
 		include_once __DIR__ . '/src/commands/' . $subcommand . '.php';
 		break;
 }


### PR DESCRIPTION
Add the `mysql` command to quickly open a `mysql` root shell into the
runnind database container of the stack.
Kudos to Lando for the idea.

Also: alias the `wp` command to the `cli` one.

[Screencast of the `mysql` command and `wp` alias in action.](https://asciinema.org/a/4QJ9x2OX2SwNHMBoNWUMp4yaU)