### PR TITLE
Fix some up issues

### DIFF
--- a/src/services.php
+++ b/src/services.php
@@ -180,24 +180,14 @@ function ensure_services_running( array $services ) {
  * @return bool Whether a service is running or not.
  */
 function service_running( $service, $set = null ) {
-	static $running_services;
+	$ps = slic_process()( [ 'ps', '--services', '--filter', '"status=running"' ] );
+	$ps_status = $ps( 'status' );
 
-	if ( $running_services === null ) {
-		// Pull from docker, ignore the set flag as it will be live.
-		$ps = slic_process()( [ 'ps', '--services', '--filter', '"status=running"' ] );
-		$ps_status = $ps( 'status' );
-
-		if ( $ps_status !== 0 ) {
-			return false;
-		}
-
-		$running_services = explode( "\n", $ps( 'string_output' ) );
-	} else if ( $set !== null ) {
-		// Update the cached value.
-		$running_services = $set ?
-			array_unique( array_merge( $running_services, [ $service ] ) )
-			: array_values( array_diff( $running_services, [ $service ] ) );
+	if ( $ps_status !== 0 ) {
+		return false;
 	}
+
+	$running_services = explode( "\n", $ps( 'string_output' ) );
 
 	return in_array( $service, $running_services, true );
 }

--- a/src/utils.php
+++ b/src/utils.php
@@ -614,14 +614,13 @@ function unzip_file( $source_file, $dest_dir ) {
 
 	$zip      = new \ZipArchive;
 	$basename = basename( $source_file );
-	$dirname  = substr( $basename, 0, strpos( $basename, '.', - strlen( $basename ) ) );
 	$tmp_dir  = cache( '/temp_zip_dir' );
 
 	if ( ! (
 		$zip->open( $source_file )
 		&& $zip->extractTo( $tmp_dir )
 		&& ( is_dir( $dest_dir ) && rrmdir( $dest_dir ) )
-		&& rename( $tmp_dir . '/' . $dirname, $dest_dir )
+		&& rename( $tmp_dir . '/wordpress', $dest_dir )
 		&& rrmdir( $tmp_dir )
 		&& $zip->close()
 	) ) {

--- a/src/wordpress.php
+++ b/src/wordpress.php
@@ -173,6 +173,9 @@ function ensure_wordpress_files( $version = null ) {
 		debug( "Previous WordPress directory not found." . PHP_EOL );
 	}
 
+	// Tear down the stack to avoid containers from locking the bound directories.
+	quietly_tear_down_stack();
+
 	// Ensure the destination directory exists.
 	if ( ! is_dir( $wp_root_dir ) && ! mkdir( $wp_root_dir, 0755, false ) && ! is_dir( $wp_root_dir ) ) {
 		echo magenta( "Failed to create WordPress root directory {$wp_root_dir}" );
@@ -180,7 +183,7 @@ function ensure_wordpress_files( $version = null ) {
 	}
 
 	// Download WordPress.
-	$zip_file = cache( '/wordpress/wordpress.zip' );
+	$zip_file = cache( "/wordpress/wordpress-$version.zip" );
 	if ( ! is_file( $zip_file ) ) {
 		debug( "WordPress zip file $zip_file not found." . PHP_EOL );
 


### PR DESCRIPTION
This PR fixes the issues I ran into while trying to run `up` on the branch.

In detail.
- refactor(services) make the service runnign check a live one, do not cache -- caching
is fine, but right now performance is faste enough not to require a caching, thus invalidation
solution.

- fix(utils.php) the name of the extracted dir will always be `wordpress` -- the zip file was not 
cached correctly and downloaded on each run; also: the name of the dir was set incorrectly. 

- fix(wordpress) tear down the stack before attempting a version update -- running containers will
file-lock the wordpress files and folders; this will kill a version update.
