### PR TITLE
Enable xdebug v3 ini settings via php.ini

### DIFF
--- a/containers/slic/Dockerfile
+++ b/containers/slic/Dockerfile
@@ -17,17 +17,17 @@ RUN chmod a+x /usr/local/bin/install-php-extensions && \
 # Install some more packages required by wp-cli and Composer.
 RUN apt-get update && apt-get install -y \
     default-mysql-client curl git zip unzip iproute2 \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* \
-
-# Use our own ini configuration file to set up some PHP default.
-COPY php.ini /usr/local/etc/php/conf.d/docker-php-defaults.ini
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Configure the uopz extension.
-COPY docker-php-ext-uopz.ini /usr/local/etc/php/conf.d/docker-php-ext-uopz.ini
+COPY ./docker-php-ext-uopz.ini /usr/local/etc/php/conf.d/docker-php-ext-uopz.ini
+
+# Use our own ini configuration file to set up some PHP default.
+COPY ./php.ini /usr/local/etc/php/conf.d/999-slic.ini
 
 # Add the XDebug control scripts.
-COPY xdebug-on.sh /usr/local/bin/xdebug-on
-COPY xdebug-off.sh /usr/local/bin/xdebug-off
+COPY ./xdebug-on.sh /usr/local/bin/xdebug-on
+COPY ./xdebug-off.sh /usr/local/bin/xdebug-off
 RUN chmod a+x /usr/local/bin/xdebug-on && \
     chmod a+x /usr/local/bin/xdebug-off
 
@@ -61,14 +61,14 @@ RUN [ $(getent group 1000) ] || addgroup --gid 1000 slic && \
     chown root:root /usr/local/bin/fixuid && \
     chmod 4755 /usr/local/bin/fixuid && \
     mkdir -p /etc/fixuid
-COPY fixuid.yml /etc/fixuid/config.yml
-COPY .bashrc /home/slic/.bashrc
-COPY .bashrc /root/.bashrc
-COPY bashrc_scripts.sh /home/slic/bashrc_scripts.sh
+COPY ./fixuid.yml /etc/fixuid/config.yml
+COPY ./.bashrc /home/slic/.bashrc
+COPY ./.bashrc /root/.bashrc
+COPY ./bashrc_scripts.sh /home/slic/bashrc_scripts.sh
 
 RUN chown -R slic:slic $NVM_DIR
 
-COPY slic-entrypoint.sh /usr/local/bin/slic-entrypoint.sh
+COPY ./slic-entrypoint.sh /usr/local/bin/slic-entrypoint.sh
 RUN chmod a+x /usr/local/bin/slic-entrypoint.sh
 ENTRYPOINT ["/usr/local/bin/slic-entrypoint.sh"]
 

--- a/containers/slic/php.ini
+++ b/containers/slic/php.ini
@@ -14,3 +14,6 @@ post_max_size=128M
 
 ;Allow long request.
 max_execution_time=300
+
+;If XDebug is active, it should always start.
+xdebug.start_with_request=yes

--- a/src/services.php
+++ b/src/services.php
@@ -118,7 +118,7 @@ function ensure_service_ready( $service ) {
 	switch ( $service ) {
 		case 'wordpress':
 			ensure_wordpress_ready();
-
+			service_up_notify( $service );
 			return static function ( $service ) {
 				propagate_ip_address_of_to(
 					[ 'wordpress' ],
@@ -126,7 +126,6 @@ function ensure_service_ready( $service ) {
 					[ 'wordpress' => 'wordpress.test' ]
 				);
 			};
-			service_up_notify( $service );
 		default:
 			return $noop;
 	}
@@ -159,7 +158,6 @@ function ensure_service_dependencies( $service ) {
 function ensure_services_running( array $services ) {
 	$on_up = [];
 	foreach ( $services as $service ) {
-		$on_up[] = ensure_service_ready( $service );
 		ensure_service_running( $service );
 	}
 


### PR DESCRIPTION
Additionally, we are being more explicit about where we're grabbing the files used in `COPY` commands.