### PR TITLE
Ensure XDebug mode is set correctly

### DIFF
--- a/containers/slic/php.ini
+++ b/containers/slic/php.ini
@@ -17,3 +17,4 @@ max_execution_time=300
 
 ;If XDebug is active, it should always start.
 xdebug.start_with_request=yes
+xdebug.mode=develop,debug


### PR DESCRIPTION
The default `xdebug.mode` value is `develop` that will not connect for step debugging to clients.

This PR updates the mode to `develop,debug`.
