### PR TITLE
Make slic shell backwards compatible with codeception.tric.yml

### DIFF
--- a/containers/slic/bashrc_scripts.sh
+++ b/containers/slic/bashrc_scripts.sh
@@ -1,6 +1,6 @@
 # Some aliases to save some typing.
-alias c="vendor/bin/codecept -c codeception.slic.yml"
-alias cr="vendor/bin/codecept -c codeception.slic.yml run"
+alias c="vendor/bin/codecept -c $(if [ -f 'codeception.slic.yml' ]; then echo 'codeception.slic.yml'; else echo 'codeception.tric.yml'; fi)"
+alias cr="vendor/bin/codecept -c $(if [ -f 'codeception.slic.yml' ]; then echo 'codeception.slic.yml'; else echo 'codeception.tric.yml'; fi) run"
 
 # Returns the path to the PHP version configuration file.
 function xdebug_config_file(){


### PR DESCRIPTION
This ensures that if `slic shell` is executed against a project that is still using `codeception.tric.yml` rather than `codeception.slic.yml`, it'll still function without needing to do `slic init`.