### PR TITLE
Retain the xdebug setting between shell executions

### DIFF
--- a/containers/slic/bashrc_scripts.sh
+++ b/containers/slic/bashrc_scripts.sh
@@ -9,23 +9,29 @@ function xdebug_config_file(){
 
 # Activates the XDebug extension.
 function xon(){
-  xdebug_config_file=$(xdebug_config_file)
-  sed -i '/^;zend_extension/ s/;zend_extension/zend_extension/g' "$xdebug_config_file"
-  php -v
+  xdebug-on
+  echo "#!/bin/bash" > ~/xdebug-setting.sh
+  echo "xdebug-on" >> ~/xdebug-setting.sh
+  chmod +x ~/xdebug-setting.sh
 }
 
 # Deactivates the XDebug extension completely.
 function xoff(){
-  xdebug_config_file=$(xdebug_config_file)
-  sed -i '/^zend_extension/ s/zend_extension/;zend_extension/g' "$xdebug_config_file"
-  php -v
+  xdebug-off
+  echo "#!/bin/bash" > ~/xdebug-setting.sh
+  echo "xdebug-off" >> ~/xdebug-setting.sh
+  chmod +x ~/xdebug-setting.sh
 }
 
-xoff
+XDEBUG_FILE=~/xdebug-setting.sh
+if [ -f "$XDEBUG_FILE" ]; then
+  . ~/xdebug-setting.sh
+else
+  xoff
+fi
 
-echo ""
-echo "  c = codecept"
-echo "  cr = codecept run"
-echo "  xon = turn xdebug on"
+echo "  c    = codecept"
+echo "  cr   = codecept run"
+echo "  xon  = turn xdebug on"
 echo "  xoff = turn xdebug off"
 echo ""

--- a/containers/slic/php.ini
+++ b/containers/slic/php.ini
@@ -18,3 +18,4 @@ max_execution_time=300
 ;If XDebug is active, it should always start.
 xdebug.start_with_request=yes
 xdebug.mode=develop,debug
+xdebug.discover_client_host=1

--- a/containers/slic/xdebug-off.sh
+++ b/containers/slic/xdebug-off.sh
@@ -3,3 +3,6 @@
 xdebug_config_file=$(php --ini | grep xdebug | cut -d, -f1)
 sed -i '/^zend_extension/ s/zend_extension/;zend_extension/g' "$xdebug_config_file"
 php -v
+echo ""
+echo "XDebug is \033[31moff\033[0m."
+echo ""

--- a/containers/slic/xdebug-on.sh
+++ b/containers/slic/xdebug-on.sh
@@ -2,3 +2,6 @@
 xdebug_config_file=$(php --ini | grep xdebug | cut -d, -f1)
 sed -i '/^;zend_extension/ s/;zend_extension/zend_extension/g' "$xdebug_config_file"
 php -v
+echo ""
+echo "XDebug is \033[32mon\033[0m."
+echo ""


### PR DESCRIPTION
This still defaults to `xoff`, but any time `xoff` or `xon` is executed, that setting is saved so that when the user re-enters `slic shell`, their XDebug state is reinstated.

Additionally, adds a friendly and colorful output of the XDebug state.